### PR TITLE
Add @MainActor isolation to generated dependency properties for Swift 6 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,17 +5,11 @@ on:
 
 jobs: 
   build-test-stitch:
-    name: Build and test with Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    name: Build and test with Swift ${{ matrix.swift }}
     strategy:
       matrix:
-        include:
-          - swift: '5.9'
-            os: macos-13
-          - swift: '6.0'
-            os: macos-latest
-          - swift: 6
-            os: macos-latest
-    runs-on: ${{ matrix.os }}
+        swift: [6]
+    runs-on: macos-latest
     steps:
       - uses: swift-actions/setup-swift@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build
-        run: swift build -v
+        run: swift build
 
       - name: Test
-        run: swift test -v
+        run: swift test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,17 @@ on:
 
 jobs: 
   build-test-stitch:
-    name: Build and test with Swift ${{ matrix.swift }}
+    name: Build and test with Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
-        swift: ['5.9', '6.0', 6]
-    runs-on: macos-latest
+        include:
+          - swift: '5.9'
+            os: macos-13
+          - swift: '6.0'
+            os: macos-latest
+          - swift: 6
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: swift-actions/setup-swift@v2
         with:

--- a/Sources/StitchMacros/StitchifyMacro.swift
+++ b/Sources/StitchMacros/StitchifyMacro.swift
@@ -28,8 +28,8 @@ public struct StitchifyMacro: MemberMacro, ExtensionMacro {
         let scoped = arguments?.first { $0.label?.text == "scoped" }?.expression ?? ".application"
         
         // add our dependency management properties and functionality
-        let scope: DeclSyntax = "static var scope: StitchableScope = \(raw: scoped)"
-        let dependency: DeclSyntax = "static var dependency: \(raw: key) = createNewInstance()"
+        let scope: DeclSyntax = "@MainActor static var scope: StitchableScope = \(raw: scoped)"
+        let dependency: DeclSyntax = "@MainActor static var dependency: \(raw: key) = createNewInstance()"
         let new: DeclSyntax = "static func createNewInstance() -> \(raw: key) { \(name)() }"
         
         return [scope, dependency, new]

--- a/Tests/StitchMacroTests/Macros/StitchMacrosTests.swift
+++ b/Tests/StitchMacroTests/Macros/StitchMacrosTests.swift
@@ -21,9 +21,9 @@ final class StitchMacrosTests: XCTestCase {
             struct SomeStruct {
                 var property: String = "test"
 
-                static var scope: StitchableScope = .application
+                @MainActor static var scope: StitchableScope = .application
 
-                static var dependency: SomeStruct  = createNewInstance()
+                @MainActor static var dependency: SomeStruct  = createNewInstance()
 
                 static func createNewInstance() -> SomeStruct  {
                     SomeStruct ()
@@ -50,9 +50,9 @@ final class StitchMacrosTests: XCTestCase {
             struct SomeStruct {
                 var property: String = "test"
 
-                static var scope: StitchableScope = .unique
+                @MainActor static var scope: StitchableScope = .unique
 
-                static var dependency: SomeStruct  = createNewInstance()
+                @MainActor static var dependency: SomeStruct  = createNewInstance()
 
                 static func createNewInstance() -> SomeStruct  {
                     SomeStruct ()
@@ -81,9 +81,9 @@ final class StitchMacrosTests: XCTestCase {
             struct SomeStruct {
                 var property: String = "test"
 
-                static var scope: StitchableScope = .application
+                @MainActor static var scope: StitchableScope = .application
 
-                static var dependency: any SomeProtocol = createNewInstance()
+                @MainActor static var dependency: any SomeProtocol = createNewInstance()
 
                 static func createNewInstance() -> any SomeProtocol {
                     SomeStruct ()
@@ -112,9 +112,9 @@ final class StitchMacrosTests: XCTestCase {
             struct SomeStruct {
                 var property: String = "test"
 
-                static var scope: StitchableScope = .cached
+                @MainActor static var scope: StitchableScope = .cached
 
-                static var dependency: SomeStruct  = createNewInstance()
+                @MainActor static var dependency: SomeStruct  = createNewInstance()
 
                 static func createNewInstance() -> SomeStruct  {
                     SomeStruct ()


### PR DESCRIPTION
## Summary

Adds `@MainActor` attribute to the generated `scope` and `dependency` static properties in the `@Stitchify` macro to ensure proper actor isolation for Swift 6 concurrency support.

## Changes

- Added `@MainActor` attribute to generated `scope` static property
- Added `@MainActor` attribute to generated `dependency` static property
- Updated all test cases to reflect the new macro expansion output with `@MainActor` attributes

## Testing

- All existing macro tests have been updated and pass with the new `@MainActor` annotations
- Verified macro expansion generates correct code for different scopes (`.application`, `.unique`, `.cached`)
- Verified macro expansion works correctly with protocol conformance