### PR TITLE
feat: add access level preservation to Stitchify macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ struct Logger {
 
 The `@Stitchify` macro respects your type's access level, automatically applying the same visibility to all generated members. This means `public` types create `public` dependencies, `private` types create `private` dependencies, and so on; enabling library authors to precisely control their API surface.
 
-This dependency can now be resolved by the Stich propertyWrappers from anywhere in the codebase, using the dependencie's type for lookup.
+This dependency can now be resolved by the Stich propertyWrappers from anywhere in the codebase, using the dependency's type for lookup.
 
 ```swift
 class Model {

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ struct Logger {
 }
 ```
 
+The `@Stitchify` macro respects your type's access level, automatically applying the same visibility to all generated members. This means `public` types create `public` dependencies, `private` types create `private` dependencies, and so on; enabling library authors to precisely control their API surface.
+
 This dependency can now be resolved by the Stich propertyWrappers from anywhere in the codebase, using the dependencie's type for lookup.
 
 ```swift
@@ -103,12 +105,14 @@ protocol SomeNetworkAbstraction {
 }
 
 @Stitchify(by: SomeNetworkAbstraction.self)
-struct NetworkImplementation {
+public struct NetworkImplementation {
     ...
 }
 ```
 
 Simply add the `by:` property to the Stitchify macro and provide the protocol type you would like to key the dependency by. Now, when you access the dependency using any of Stitch's @propertyWrappers you will get the dependency by its abstraction, not its concrete type.
+
+**Access Control**: The macro automatically inherits your type's access level (public, internal, fileprivate, private, or package) and applies it to all generated dependency management members. In the example above, marking `NetworkImplementation` as `public` ensures the generated `scope`, `dependency`, and `createNewInstance()` members are also `public`, making them accessible across module boundaries.
 
 ```swift
 struct SomeInteractor {

--- a/Sources/Stitch/Stitchify/Stitchify.swift
+++ b/Sources/Stitch/Stitchify/Stitchify.swift
@@ -8,12 +8,16 @@
 
 /// Macro that wraps a type as a `Stitchable`, to be used for injection.
 ///
-/// The `Stitchify` macro is used to convert a type into a `Stitchable`. It accepts optional parameters for the `type` and `scoped`.
-/// The `type` parameter specifies the keyed type to be stored against and to be referenced when resolving.
+/// The `Stitchify` macro is used to convert a type into a `Stitchable`. It accepts optional parameters for the `by` and `scoped`.
+/// The `by` parameter specifies the keyed type to be stored against and to be referenced when resolving.
 /// The `scoped` parameter specifies the `StitchableScope` of the stitchable representation.
 ///
+/// The macro automatically inherits the access level of the annotated type (public, internal, fileprivate, private, or package)
+/// and applies it to all generated members (`scope`, `dependency`, `createNewInstance()`), ensuring consistent visibility
+/// across your dependency injection setup.
+///
 /// - Parameters:
-///   - type: Optional type to be stitched by. When not provided, the type will be stitched against its concrete type.
+///   - by: Optional type to be stitched by. When not provided, the type will be stitched against its concrete type.
 ///   - scoped: The scope of the stitchable representation. Defaults to `.application`.
 @attached(member, names: named(scope), named(dependency), named(init), named(createNewInstance))
 @attached(extension, conformances: Stitchable)

--- a/Tests/StitchMacroTests/Macros/StitchMacrosTests.swift
+++ b/Tests/StitchMacroTests/Macros/StitchMacrosTests.swift
@@ -127,4 +127,209 @@ final class StitchMacrosTests: XCTestCase {
             macros: testMacros
         )
     }
+    
+    func testStitchifyExpandsWithPublicAccessLevel() {
+        assertMacroExpansion(
+            """
+            @Stitchify
+            public struct SomeStruct {
+                var property: String = "test"
+            }
+            """,
+            expandedSource: """
+            
+            public struct SomeStruct {
+                var property: String = "test"
+
+                @MainActor public static var scope: StitchableScope = .application
+
+                @MainActor public static var dependency: SomeStruct  = createNewInstance()
+
+                public static func createNewInstance() -> SomeStruct  {
+                    SomeStruct ()
+                }
+            }
+
+            extension SomeStruct : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testStitchifyExpandsWithPublicAccessLevelAndProtocol() {
+        assertMacroExpansion(
+            """
+            protocol SomeProtocol {}
+            
+            @Stitchify(by: SomeProtocol.self)
+            public class SomeClass {
+                init() {}
+            }
+            """,
+            expandedSource: """
+            protocol SomeProtocol {}
+            public class SomeClass {
+                init() {}
+
+                @MainActor public static var scope: StitchableScope = .application
+
+                @MainActor public static var dependency: any SomeProtocol = createNewInstance()
+
+                public static func createNewInstance() -> any SomeProtocol {
+                    SomeClass ()
+                }
+            }
+
+            extension SomeClass : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testStitchifyExpandsWithPrivateAccessLevel() {
+        assertMacroExpansion(
+            """
+            @Stitchify
+            private struct SomeStruct {
+                var property: String = "test"
+            }
+            """,
+            expandedSource: """
+            
+            private struct SomeStruct {
+                var property: String = "test"
+
+                @MainActor private static var scope: StitchableScope = .application
+
+                @MainActor private static var dependency: SomeStruct  = createNewInstance()
+
+                private static func createNewInstance() -> SomeStruct  {
+                    SomeStruct ()
+                }
+            }
+
+            extension SomeStruct : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testStitchifyExpandsWithFileprivateAccessLevel() {
+        assertMacroExpansion(
+            """
+            @Stitchify
+            fileprivate struct SomeStruct {
+                var property: String = "test"
+            }
+            """,
+            expandedSource: """
+            
+            fileprivate struct SomeStruct {
+                var property: String = "test"
+
+                @MainActor fileprivate static var scope: StitchableScope = .application
+
+                @MainActor fileprivate static var dependency: SomeStruct  = createNewInstance()
+
+                fileprivate static func createNewInstance() -> SomeStruct  {
+                    SomeStruct ()
+                }
+            }
+
+            extension SomeStruct : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testStitchifyExpandsWithPackageAccessLevel() {
+        assertMacroExpansion(
+            """
+            @Stitchify
+            package struct SomeStruct {
+                var property: String = "test"
+            }
+            """,
+            expandedSource: """
+            
+            package struct SomeStruct {
+                var property: String = "test"
+
+                @MainActor package static var scope: StitchableScope = .application
+
+                @MainActor package static var dependency: SomeStruct  = createNewInstance()
+
+                package static func createNewInstance() -> SomeStruct  {
+                    SomeStruct ()
+                }
+            }
+
+            extension SomeStruct : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testStitchifyExpandsOnEnum() {
+        assertMacroExpansion(
+            """
+            @Stitchify
+            public enum SomeEnum {
+                case value
+            }
+            """,
+            expandedSource: """
+            
+            public enum SomeEnum {
+                case value
+
+                @MainActor public static var scope: StitchableScope = .application
+
+                @MainActor public static var dependency: SomeEnum  = createNewInstance()
+
+                public static func createNewInstance() -> SomeEnum  {
+                    SomeEnum ()
+                }
+            }
+
+            extension SomeEnum : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testStitchifyExpandsOnActor() {
+        assertMacroExpansion(
+            """
+            @Stitchify
+            public actor SomeActor {
+                init() {}
+            }
+            """,
+            expandedSource: """
+            
+            public actor SomeActor {
+                init() {}
+
+                @MainActor public static var scope: StitchableScope = .application
+
+                @MainActor public static var dependency: SomeActor  = createNewInstance()
+
+                public static func createNewInstance() -> SomeActor  {
+                    SomeActor ()
+                }
+            }
+
+            extension SomeActor : Stitchable {
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }


### PR DESCRIPTION
## Summary

The `@Stitchify` macro now automatically inherits and applies the access level of the annotated type to all generated dependency management members (`scope`, `dependency`, `createNewInstance()`). This ensures consistent visibility control and enables library authors to precisely manage their API surface when using Stitch for dependency injection.

## Changes

- **StitchifyMacro**: Added `extractAccessLevel()` function to detect access modifiers (public, internal, fileprivate, private, package) from type declarations
- **StitchifyMacro**: Modified member generation to preserve the detected access level on generated static properties and methods
- **Documentation**: Updated README.md with access level inheritance behavior and examples
- **Documentation**: Updated inline documentation in `Stitchify.swift` to describe access level preservation
- **Tests**: Added 205 lines of comprehensive test coverage in `StitchMacrosTests.swift` to verify access level preservation across all modifiers

## Testing

- Run the test suite to verify access level preservation for all access modifiers (public, internal, fileprivate, private, package)
- Verify that `public` types generate `public` dependencies and methods
- Verify that types without explicit access modifiers default to internal
- Confirm that the macro correctly handles the `by:` parameter with different access levels